### PR TITLE
Configure K3S server

### DIFF
--- a/traits/server/nixos-host.nix
+++ b/traits/server/nixos-host.nix
@@ -1,20 +1,9 @@
 # NixOS-specific server host configuration.
 # https://search.nixos.org/options
-{ pkgs, ... }: with pkgs; {
-  imports = [ ];
-
-  # This is to demonstrate how nixos offers support for k3s. But, I want to set this
-  # a bit more directly first and then may migrate to this when I know what I want.
-  # Ref: https://search.nixos.org/options?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=k3s
-  # services.k3s = {
-  #   enable = true;
-  #   role = "server"; # Server also acts as an agent.
-  # };
-
-  environment.systemPackages = [
-    k3s
+{ ... }: {
+  imports = [
+    ./services/k3s
   ];
-
 
   security.sudo.execWheelOnly = true;
 

--- a/traits/server/services/k3s/default.nix
+++ b/traits/server/services/k3s/default.nix
@@ -1,8 +1,9 @@
-{ ... }: {
+{ config, ... }: {
   services.k3s = {
     enable = true;
     role = "server";
     configPath = ./server.yaml;
+    extraFlags = ''--node-label "host=${config.networking.hostName}"'';
   };
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];

--- a/traits/server/services/k3s/default.nix
+++ b/traits/server/services/k3s/default.nix
@@ -1,0 +1,13 @@
+{ ... }: {
+  services.k3s = {
+    enable = true;
+    role = "server";
+    configPath = ./server.yaml;
+  };
+
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
+
+  environment.sessionVariables = {
+    KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
+  };
+}

--- a/traits/server/services/k3s/server.yaml
+++ b/traits/server/services/k3s/server.yaml
@@ -1,5 +1,5 @@
 write-kubeconfig-mode: "0644"
 cluster-init: true
 node-label:
-  - "host=noosh"
+  - "os=nixos"
 

--- a/traits/server/services/k3s/server.yaml
+++ b/traits/server/services/k3s/server.yaml
@@ -1,0 +1,9 @@
+write-kubeconfig-mode: "0644"
+cluster-init: true
+
+# Coupling server with noosh host for now, but this will be generlized later.
+tls-san:
+  - "noosh.local"
+node-label:
+  - "host=noosh"
+

--- a/traits/server/services/k3s/server.yaml
+++ b/traits/server/services/k3s/server.yaml
@@ -1,9 +1,5 @@
 write-kubeconfig-mode: "0644"
 cluster-init: true
-
-# Coupling server with noosh host for now, but this will be generlized later.
-tls-san:
-  - "noosh.local"
 node-label:
   - "host=noosh"
 


### PR DESCRIPTION
- server: configures k3s server
- server: removes tls-san k3s option because it is not used
- server: set host node label with dynamic value
