### PR TITLE
Setup ek pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Output from nix build
 /result
 

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,7 @@
+# List available commands.
+list:
+  @just -l
+
+# Create GitHub SSH keys using web login flow.
+auth-git:
+  gh auth login -p ssh -w

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+echo "Checking for Homebrew..."
+if ! command -v homebrew &> /dev/null; then
+  echo "Homebrew not found, installing Homebrew."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+else
+  echo "Hombrew already installed."
+fi
+
 nix --extra-experimental-features "nix-command flakes" \
   build ".#darwinConfigurations.$(hostname -s).system"
 

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -33,4 +33,11 @@ in
     traits = [ "devbox" "guibox" ];
     modules = [ ./eksys_pro ];
   };
+
+  ek_pro = mkHost {
+    system = "aarch64-darwin";
+    user = "erik.krieg";
+    traits = [ "devbox" "guibox" ];
+    modules = [ ./ek_pro ];
+  };
 }

--- a/hosts/darwin/ek_pro/default.nix
+++ b/hosts/darwin/ek_pro/default.nix
@@ -1,0 +1,14 @@
+{ ... }: {
+  homebrew = {
+    casks = [
+      "google-chrome"
+      "minikube"
+      "tunnelblick"
+      "visual-studio-code"
+      "raycast"
+    ];
+  };
+
+  # Changing the binary for sh conflicts with tools like Jamf CLI.
+  system.activationScripts.setDashAsSh.enable = false;
+}

--- a/hosts/darwin/ek_pro/default.nix
+++ b/hosts/darwin/ek_pro/default.nix
@@ -1,14 +1,12 @@
-{ ... }: {
+{ lib, ... }: {
   homebrew = {
     casks = [
       "google-chrome"
-      "minikube"
-      "tunnelblick"
-      "visual-studio-code"
       "raycast"
     ];
   };
 
   # Changing the binary for sh conflicts with tools like Jamf CLI.
   system.activationScripts.setDashAsSh.enable = false;
+  services.tailscale.enable = lib.mkForce false;
 }

--- a/traits/guibox/darwin-host.nix
+++ b/traits/guibox/darwin-host.nix
@@ -1,4 +1,4 @@
-{ ... }: {
+{ pkgs, ... }: with pkgs; {
   # Configure Finder 
   system.defaults = {
     finder.AppleShowAllExtensions = true;
@@ -28,6 +28,10 @@
   };
 
   environment.systemPath = [ "/opt/homebrew/bin" ];
+
+  # System packages end up in /Applications and can be opened with Spotlight
+  # if `nobrowse` is removed from `/etc/fstab`
+  environment.systemPackages = [ alacritty ];
 
   services = {
     yabai = {


### PR DESCRIPTION
Adds new host, `ek_pro` and makes some fixes and improvements for setting up a new host.

Fixes:
- Install Homebrew in bootstrap script since nix-darwin does not actually install homebrew
- Disable tailscale because it breaks DNS on hosts that are not authenticated
- Makes Alacritty a nix-darwin system package because this gets the `.app` linked in `/Applications` so that Spotlight can find it.
  - I was unable to find a nice way to get home-manager's app folder in /Applications, but this can be done through activation scripts.

New:
- Justfile with command to authenticate with GitHub