### PR TITLE
upgrade/nixos 23.11

### DIFF
--- a/hosts/nixos/chips/default.nix
+++ b/hosts/nixos/chips/default.nix
@@ -36,8 +36,6 @@
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBxcsEfj6Tnq8qJt3WFLYM4EwBYWwL4mr458vNVqDn1W ek@june"
   ];
 
-  nixpkgs.config.allowUnfree = true;
-
   environment.systemPackages = with pkgs; [
     git
     vim

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -1,7 +1,8 @@
 { nixpkgs, unstable, disko, home-manager, envim, ... }@args:
 let
+  config = { allowUnfree = true; };
   mkHost = { system, user, traits, modules ? [ ] }: (nixpkgs.lib.nixosSystem) {
-    pkgs = import nixpkgs { inherit system; };
+    pkgs = import nixpkgs { inherit system; config = config; };
     modules = modules ++ [
       home-manager.nixosModules.home-manager
       {

--- a/hosts/nixos/june/default.nix
+++ b/hosts/nixos/june/default.nix
@@ -41,8 +41,6 @@
     shell = pkgs.zsh;
   };
 
-  nixpkgs.config.allowUnfree = true;
-
   environment.systemPackages = with pkgs; [
     git
     vim

--- a/hosts/nixos/june/default.nix
+++ b/hosts/nixos/june/default.nix
@@ -55,7 +55,8 @@
 
   services.k3s = {
     clusterInit = lib.mkForce false;
-    serverAddr = "https://chips.eksys.dev:6443";
+    # serverAddr = "https://chips.eksys.dev:6443";
+    serverAddr = "https://192.168.1.17:6443";
     tokenFile = /var/lib/rancher/k3s/server/token;
   };
 

--- a/hosts/nixos/noosh/default.nix
+++ b/hosts/nixos/noosh/default.nix
@@ -73,8 +73,6 @@
     shell = pkgs.zsh;
   };
 
-  nixpkgs.config.allowUnfree = true;
-
   environment.systemPackages = with pkgs; [
     vim
   ];

--- a/traits/devbox/common-host.nix
+++ b/traits/devbox/common-host.nix
@@ -36,11 +36,8 @@
   # Configure fonts
   fonts = {
     fontDir.enable = true; # Danger: `true` mean fonts can get removed.
-    fonts = [ (nerdfonts.override { fonts = [ "Meslo" ]; }) ];
+    packages = [ (nerdfonts.override { fonts = [ "Meslo" ]; }) ];
   };
-
-  nixpkgs.config.allowUnfree = true;
-
 
   # Show changes after a rebuild.
   # https://gist.github.com/luishfonseca/f183952a77e46ccd6ef7c907ca424517?permalink_comment_id=4620275#gistcomment-4620275 

--- a/traits/server/services/k3s/default.nix
+++ b/traits/server/services/k3s/default.nix
@@ -1,7 +1,8 @@
 { config, ... }: {
   imports = [ ./longhorn.nix ];
   services.k3s = {
-    enable = true;
+    # enable = true;
+    enable = false;
     role = "server";
     configPath = ./server.yaml;
     clusterInit = true;

--- a/traits/server/services/k3s/default.nix
+++ b/traits/server/services/k3s/default.nix
@@ -1,8 +1,7 @@
 { config, ... }: {
   imports = [ ./longhorn.nix ];
   services.k3s = {
-    # enable = true;
-    enable = false;
+    enable = true;
     role = "server";
     configPath = ./server.yaml;
     clusterInit = true;

--- a/traits/server/services/tailscale/default.nix
+++ b/traits/server/services/tailscale/default.nix
@@ -1,6 +1,6 @@
 { config, pkgs, ... }: with pkgs; {
   services.tailscale = {
-    enable = true;
+    enable = false;
     useRoutingFeatures = "server";
   };
 

--- a/traits/server/services/tailscale/default.nix
+++ b/traits/server/services/tailscale/default.nix
@@ -5,6 +5,7 @@
   };
 
   systemd.services.tailscale-up = {
+    enable = config.services.k3s.enable && config.services.tailscale.enable;
     after = [ "tailscale.service" "k3s.service" ];
     wants = [ "tailscale.service" "k3s.service" ];
     wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
- disable tailscale-up service if tailscale or k3s is not enabled
- disable k3s for now
- fix some issues updating to 23.11 nixos
